### PR TITLE
Make the nodePort configurable for both RPC and gateway

### DIFF
--- a/operator/src/controller.rs
+++ b/operator/src/controller.rs
@@ -316,12 +316,14 @@ impl Devnet {
                 name: Some("rpc".to_string()),
                 port: 9575,
                 target_port: Some(IntOrString::String("rpc".to_string())),
+                node_port: self.spec.node_port_rpc.clone(),
                 ..ServicePort::default()
             },
             ServicePort {
                 name: Some("gateway".to_string()),
                 port: 5050,
                 target_port: Some(IntOrString::String("gateway".to_string())),
+                node_port: self.spec.node_port_gateway.clone(),
                 ..ServicePort::default()
             }]),
             ..ServiceSpec::default()

--- a/operator/src/devnet.rs
+++ b/operator/src/devnet.rs
@@ -31,6 +31,10 @@ pub struct DevnetSpec {
     pub extra_args: Option<Vec<String>>,
     /// Specify how the service is exposed.
     pub service_type: Option<String>,
+    /// Specify the node port of the RPC. Defaults to a k8s assigned port.
+    pub node_port_rpc: Option<i32>,
+    /// Specify the node port of the gateway. Defaults to a k8s assigned port.
+    pub node_port_gateway: Option<i32>,
 }
 
 /// State of the devnet.


### PR DESCRIPTION
This also allows deleting the CRD because it needs to be updated if you have already created it.